### PR TITLE
Initialize beans lazily

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,8 @@ server:
 
 
 spring:
+  main:
+    lazy-initialization: true
   data.mongodb:
     auto-index-creation: false
     uri: mongodb://${DATABASE_USER}:${DATABASE_PASSWORD}@localhost:27017/${DATABASE_NAME}


### PR DESCRIPTION
This will allow contributors run a local server without requiring them to set all of the environment variables that will only be needed in some cases and that will require a lot of configurations like (google credentials and the mail server variables).