### PR TITLE
Filter sabeq out

### DIFF
--- a/src/main/java/com/azkar/configs/CategoriesCacher.java
+++ b/src/main/java/com/azkar/configs/CategoriesCacher.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.ClassPathResource;
 
@@ -30,6 +31,7 @@ public class CategoriesCacher {
   List<Category> categories = new ArrayList<>();
 
   @Bean
+  @Lazy(value = false)
   @Primary
   public CategoriesCacher parseCategoriesFromCsv() {
     CategoriesCacher categoriesCacher = new CategoriesCacher();

--- a/src/main/java/com/azkar/configs/DbMigrations.java
+++ b/src/main/java/com/azkar/configs/DbMigrations.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,7 @@ public class DbMigrations {
   private String dbName;
 
   @Bean
+  @Lazy(value = false)
   public Mongobee mongobee() {
     Mongobee runner = new Mongobee(dbUri);
     runner.setDbName(dbName);         // host must be set if not set in URI
@@ -41,7 +43,7 @@ public class DbMigrations {
     return runner;
   }
 
-  @ChangeSet(order = "0001", id = "addSabeq8", author = "")
+  @ChangeSet(order = "0001", id = "addSabeq", author = "")
   public void addSabeq(MongoTemplate mongoTemplate) {
     // Check the unicode displayed at https://emojipedia.org/racing-car/
     User sabeq = User.builder()

--- a/src/main/java/com/azkar/controllers/ChallengeController.java
+++ b/src/main/java/com/azkar/controllers/ChallengeController.java
@@ -18,6 +18,8 @@ import com.azkar.payload.challengecontroller.responses.GetChallengeResponse;
 import com.azkar.payload.challengecontroller.responses.GetChallengesResponse;
 import com.azkar.payload.challengecontroller.responses.UpdateChallengeResponse;
 import com.azkar.payload.exceptions.BadRequestException;
+import com.azkar.payload.utils.FeaturesVersions;
+import com.azkar.payload.utils.VersionComparator;
 import com.azkar.repos.ChallengeRepo;
 import com.azkar.repos.FriendshipRepo;
 import com.azkar.repos.GroupRepo;
@@ -31,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.swing.text.html.Option;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -460,10 +463,26 @@ public class ChallengeController extends BaseController {
     if (apiVersion != null) {
       logger.info("API version requested is " + apiVersion);
     }
+    List<Challenge> userChallenges = getCurrentUser(userRepo).getUserChallenges();
+    if (VersionComparator.compare(apiVersion, FeaturesVersions.SABEQ_ADDITION_VERSION) < 0) {
+      userChallenges = filterOutSabeqChallenges(userChallenges);
+    }
+
     GetChallengesResponse response = new GetChallengesResponse();
-    response.setData(getCurrentUser(userRepo).getUserChallenges());
+    response.setData(userChallenges);
     Collections.reverse(response.getData());
     return ResponseEntity.ok(response);
+  }
+
+  private List<Challenge> filterOutSabeqChallenges(List<Challenge> challenges) {
+    List<Challenge> filtered = challenges.stream().filter(challenge -> {
+      Optional<Group> group = groupRepo.findById(challenge.getGroupId());
+      if (!group.isPresent()) {
+        return false;
+      }
+      return !group.get().getUsersIds().contains(User.SABEQ_ID);
+    }).collect(Collectors.toList());
+    return filtered;
   }
 
   @GetMapping(path = "/groups/{groupId}/")

--- a/src/main/java/com/azkar/controllers/ChallengeController.java
+++ b/src/main/java/com/azkar/controllers/ChallengeController.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.swing.text.html.Option;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/azkar/payload/utils/FeaturesVersions.java
+++ b/src/main/java/com/azkar/payload/utils/FeaturesVersions.java
@@ -1,5 +1,6 @@
 package com.azkar.payload.utils;
 
 public class FeaturesVersions {
+
   public static final String SABEQ_ADDITION_VERSION = "1.4.0";
 }

--- a/src/main/java/com/azkar/payload/utils/FeaturesVersions.java
+++ b/src/main/java/com/azkar/payload/utils/FeaturesVersions.java
@@ -1,0 +1,5 @@
+package com.azkar.payload.utils;
+
+public class FeaturesVersions {
+  public static final String SABEQ_ADDITION_VERSION = "1.4.0";
+}

--- a/src/main/java/com/azkar/payload/utils/VersionComparator.java
+++ b/src/main/java/com/azkar/payload/utils/VersionComparator.java
@@ -1,19 +1,22 @@
 package com.azkar.payload.utils;
 
 public class VersionComparator {
+
   public static int compare(String v1, String v2) {
     String[] v1Parts = v1.split("\\.");
     String[] v2Parts = v2.split("\\.");
     int length = Math.max(v1Parts.length, v2Parts.length);
-    for(int i = 0; i < length; i++) {
+    for (int i = 0; i < length; i++) {
       int v1Part = i < v1Parts.length ?
           Integer.parseInt(v1Parts[i]) : 0;
       int v2Part = i < v2Parts.length ?
           Integer.parseInt(v2Parts[i]) : 0;
-      if(v1Part < v2Part)
+      if (v1Part < v2Part) {
         return -1;
-      if(v1Part > v2Part)
+      }
+      if (v1Part > v2Part) {
         return 1;
+      }
     }
     return 0;
   }

--- a/src/main/java/com/azkar/payload/utils/VersionComparator.java
+++ b/src/main/java/com/azkar/payload/utils/VersionComparator.java
@@ -1,0 +1,20 @@
+package com.azkar.payload.utils;
+
+public class VersionComparator {
+  public static int compare(String v1, String v2) {
+    String[] v1Parts = v1.split("\\.");
+    String[] v2Parts = v2.split("\\.");
+    int length = Math.max(v1Parts.length, v2Parts.length);
+    for(int i = 0; i < length; i++) {
+      int v1Part = i < v1Parts.length ?
+          Integer.parseInt(v1Parts[i]) : 0;
+      int v2Part = i < v2Parts.length ?
+          Integer.parseInt(v2Parts[i]) : 0;
+      if(v1Part < v2Part)
+        return -1;
+      if(v1Part > v2Part)
+        return 1;
+    }
+    return 0;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ server:
     key-store-password: ${KEY_STORE_PASSWORD}
     key-store-type: PKCS12
     key-store: classpath:tanafaso.p12
-    enabled: false
+    enabled: true
 
 
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 debug: true
 app:
   jwtSecret: ${JWT_SECRET}
-  version: 1.3.0
+  version: 1.4.0
 
 org:
   springframework:
@@ -16,7 +16,7 @@ server:
     key-store-password: ${KEY_STORE_PASSWORD}
     key-store-type: PKCS12
     key-store: classpath:tanafaso.p12
-    enabled: true
+    enabled: false
 
 
 spring:


### PR DESCRIPTION
This change is to only return sabeq as a friend and to only return challenges with sabeq in case the frontend version is new enough. This is to not confuse the users of the old version by seeing a new friend and new challenges without any introductions. Introducing sabeq will be added in the new frontend version.