### PR TITLE
[Sabeq] Test different responses on different API versions

### DIFF
--- a/src/main/java/com/azkar/controllers/ChallengeController.java
+++ b/src/main/java/com/azkar/controllers/ChallengeController.java
@@ -463,7 +463,8 @@ public class ChallengeController extends BaseController {
       logger.info("API version requested is " + apiVersion);
     }
     List<Challenge> userChallenges = getCurrentUser(userRepo).getUserChallenges();
-    if (VersionComparator.compare(apiVersion, FeaturesVersions.SABEQ_ADDITION_VERSION) < 0) {
+    if (apiVersion == null
+        || VersionComparator.compare(apiVersion, FeaturesVersions.SABEQ_ADDITION_VERSION) < 0) {
       userChallenges = filterOutSabeqChallenges(userChallenges);
     }
 

--- a/src/main/java/com/azkar/controllers/FriendshipController.java
+++ b/src/main/java/com/azkar/controllers/FriendshipController.java
@@ -73,7 +73,8 @@ public class FriendshipController extends BaseController {
     List<FriendshipScores> friendsScores = new ArrayList<>();
     Friendship friendship = friendshipRepo.findByUserId(getCurrentUser().getUserId());
     List<Friend> friends = friendship.getFriends();
-    if (VersionComparator.compare(apiVersion, FeaturesVersions.SABEQ_ADDITION_VERSION) < 0) {
+    if (apiVersion == null
+        || VersionComparator.compare(apiVersion, FeaturesVersions.SABEQ_ADDITION_VERSION) < 0) {
       friends = friends.stream().filter(friend -> !friend.getUserId().equals(User.SABEQ_ID))
           .collect(Collectors.toList());
     }

--- a/src/main/java/com/azkar/payload/utils/VersionComparator.java
+++ b/src/main/java/com/azkar/payload/utils/VersionComparator.java
@@ -7,10 +7,8 @@ public class VersionComparator {
     String[] v2Parts = v2.split("\\.");
     int length = Math.max(v1Parts.length, v2Parts.length);
     for (int i = 0; i < length; i++) {
-      int v1Part = i < v1Parts.length ?
-          Integer.parseInt(v1Parts[i]) : 0;
-      int v2Part = i < v2Parts.length ?
-          Integer.parseInt(v2Parts[i]) : 0;
+      int v1Part = i < v1Parts.length ? Integer.parseInt(v1Parts[i]) : 0;
+      int v2Part = i < v2Parts.length ? Integer.parseInt(v2Parts[i]) : 0;
       if (v1Part < v2Part) {
         return -1;
       }

--- a/src/test/java/com/azkar/controllers/friendshipcontroller/FriendshipTest.java
+++ b/src/test/java/com/azkar/controllers/friendshipcontroller/FriendshipTest.java
@@ -523,6 +523,10 @@ public class FriendshipTest extends TestBase {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(content().json(JsonHandler.toJson(expectedResponse), /*strict=*/false));
+    azkarApi.getFriendsLeaderboardWithApiVersion(user1, "1.3.9")
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(JsonHandler.toJson(expectedResponse), /*strict=*/false));
   }
 
   @Test

--- a/src/test/java/com/azkar/controllers/utils/AzkarApi.java
+++ b/src/test/java/com/azkar/controllers/utils/AzkarApi.java
@@ -204,6 +204,11 @@ public class AzkarApi {
     return httpClient.performGetRequest(user, "/friends/leaderboard");
   }
 
+  public ResultActions getFriendsLeaderboardWithApiVersion(User user, String apiVersion)
+      throws Exception {
+    return httpClient.performGetRequestWithApiVersion(user, "/friends/leaderboard", apiVersion);
+  }
+
   public void makeFriends(User user1, User user2) throws Exception {
     sendFriendRequest(user1, user2);
     acceptFriendRequest(user2, user1);

--- a/src/test/java/com/azkar/controllers/utils/HttpClient.java
+++ b/src/test/java/com/azkar/controllers/utils/HttpClient.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.azkar.controllers.BaseController;
 import com.azkar.entities.User;
 import java.io.UnsupportedEncodingException;
 import java.util.Date;
@@ -37,6 +38,14 @@ public class HttpClient {
 
   public ResultActions performGetRequest(User user, String path) throws Exception {
     MockHttpServletRequestBuilder requestBuilder = get(path);
+    addAuthenticationToken(requestBuilder, user);
+    return mockMvc.perform(requestBuilder);
+  }
+
+  public ResultActions performGetRequestWithApiVersion(User user, String path, String apiVersion)
+      throws Exception {
+    MockHttpServletRequestBuilder requestBuilder = get(path);
+    requestBuilder.header(BaseController.API_VERSION_HEADER, apiVersion);
     addAuthenticationToken(requestBuilder, user);
     return mockMvc.perform(requestBuilder);
   }


### PR DESCRIPTION
This change adds tests that check that sabeq is returned as a friend only to frontend clients who are ready for the new API version.